### PR TITLE
Add missing example for 'require' specification

### DIFF
--- a/source/v1.16/gemfile.html.haml
+++ b/source/v1.16/gemfile.html.haml
@@ -65,7 +65,7 @@
         If a gem's main file is different than the gem name, specify how to require it.
       :code
         # lang: ruby
-        gem 'rspec'
+        gem 'rack-cache', :require => 'rack/cache'
         gem 'sqlite3'
       .description
         Specify <code>:require => false</code> to prevent bundler from requiring the gem, but still install it and maintain dependencies.


### PR DESCRIPTION
This commit adds an example that's consistent with this page:
https://github.com/bundler/bundler-site/blob/master/source/v1.16/rationale.html.haml

Previously, there was no example of what the documentation was describing.

If this PR looks good, I can update it to include updated documentation for other versions besides 1.16 also. Let me know!